### PR TITLE
Correctly manage Content-Length on HEAD responses (#2277) (#2289)

### DIFF
--- a/Sources/NIOHTTP1/HTTPDecoder.swift
+++ b/Sources/NIOHTTP1/HTTPDecoder.swift
@@ -113,6 +113,9 @@ private class BetterHTTPParser {
         }
         self.settings.pointee.on_message_complete = { opaque in
             BetterHTTPParser.fromOpaque(opaque).didReceiveMessageCompleteNotification()
+            // Temporary workaround for https://github.com/nodejs/llhttp/issues/202, should be removed
+            // when that issue is fixed. We're tracking the work in https://github.com/apple/swift-nio/issues/2274.
+            opaque?.pointee.content_length = 0
             return 0
         }
         self.withExclusiveHTTPParser { parserPtr in

--- a/Tests/NIOHTTP1Tests/HTTPDecoderTest+XCTest.swift
+++ b/Tests/NIOHTTP1Tests/HTTPDecoderTest+XCTest.swift
@@ -66,6 +66,8 @@ extension HTTPDecoderTest {
                 ("testDecodingInvalidTrailerFieldNames", testDecodingInvalidTrailerFieldNames),
                 ("testDecodingInvalidHeaderFieldValues", testDecodingInvalidHeaderFieldValues),
                 ("testDecodingInvalidTrailerFieldValues", testDecodingInvalidTrailerFieldValues),
+                ("testDecodeAfterHEADResponse", testDecodeAfterHEADResponse),
+                ("testDecodeAfterHEADResponseChunked", testDecodeAfterHEADResponseChunked),
            ]
    }
 }


### PR DESCRIPTION
Motivation

When we receive a HEAD response, it's possible that the response contains a content-length. llhttp has a bug
(https://github.com/nodejs/llhttp/issues/202) that prevents it from properly managing that issue, which causes us to incorrectly parse responses.

Modifications

Forcibly set llhttp's content-length value to 0.

Result

Correctly handle HTTP framing around llhttp's issues.

(cherry picked from commit 5aa44987f8b6a2a007b1c7792f88b630a18d3b3a)

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
